### PR TITLE
fix extract-text-webpack-plugin dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,36 +1,36 @@
 {
-    "scripts": {
-        "start": "webpack-dev-server --inline --hot --port 8089"
-    },
-    "dependencies": {
-        "axios": "^0.15.3",
-        "moment": "^2.17.1",
-        "moment-timezone": "^0.5.11",
-        "react": "^15.4.2",
-        "react-bootstrap": "^0.30.7",
-        "react-cookie": "^1.0.4",
-        "react-dom": "^15.4.2",
-        "react-js-pagination": "^2.0.2",
-        "react-moment": "^0.2.2",
-        "react-redux": "^5.0.2",
-        "react-router": "^3.0.2",
-        "redux": "^3.6.0",
-        "redux-form": "6.0.0-rc.3",
-        "redux-thunk": "^2.2.0",
-        "smoothscroll": "^0.3.0"
-    },
-    "devDependencies": {
-        "babel-core": "^6.22.1",
-        "babel-loader": "^6.2.10",
-        "babel-preset-es2015": "^6.22.0",
-        "babel-preset-react": "^6.22.0",
-        "babel-preset-stage-0": "^6.22.0",
-        "css-loader": "^0.26.1",
-        "extract-text-webpack-plugin": "2.0.0-beta",
-        "node-sass": "^4.5.0",
-        "sass-loader": "^5.0.1",
-        "style-loader": "^0.13.1",
-        "webpack": "^2.2.1",
-        "webpack-dev-server": "^2.3.0"
-    }
+  "scripts": {
+    "start": "webpack-dev-server --inline --hot --port 8089"
+  },
+  "dependencies": {
+    "axios": "^0.15.3",
+    "moment": "^2.17.1",
+    "moment-timezone": "^0.5.11",
+    "react": "^15.4.2",
+    "react-bootstrap": "^0.30.7",
+    "react-cookie": "^1.0.4",
+    "react-dom": "^15.4.2",
+    "react-js-pagination": "^2.0.2",
+    "react-moment": "^0.2.2",
+    "react-redux": "^5.0.2",
+    "react-router": "^3.0.2",
+    "redux": "^3.6.0",
+    "redux-form": "6.0.0-rc.3",
+    "redux-thunk": "^2.2.0",
+    "smoothscroll": "^0.3.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.22.1",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-react": "^6.22.0",
+    "babel-preset-stage-0": "^6.22.0",
+    "css-loader": "^0.26.1",
+    "extract-text-webpack-plugin": "^2.1.0",
+    "node-sass": "^4.5.0",
+    "sass-loader": "^5.0.1",
+    "style-loader": "^0.13.1",
+    "webpack": "^2.2.1",
+    "webpack-dev-server": "^2.3.0"
+  }
 }


### PR DESCRIPTION
Fresh install failed with following error.

```
npm ERR! Darwin 16.3.0
npm ERR! argv "/usr/local/Cellar/node/7.1.0/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v7.1.0
npm ERR! npm  v3.10.9
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: extract-text-webpack-plugin@2.0.0-beta
npm ERR! notarget Valid install targets:
npm ERR! notarget 2.1.0, 2.0.0, 2.0.0-rc.3, 2.0.0-rc.2, 2.0.0-rc.1, 2.0.0-rc.0, 2.0.0-beta.5, 2.0.0-beta.4, 2.0.0-beta.3, 2.0.0-beta.2, 2.0.0-beta.1, 2.0.0-beta.0, 1.0.1, 1.0.0, 0.9.1, 0.9.0, 0.8.2, 0.8.1, 0.8.0, 0.7.1, 0.7.0, 0.6.0, 0.5.0, 0.4.0, 0.3.8, 0.3.7, 0.3.6, 0.3.5, 0.3.4, 0.3.3, 0.3.2, 0.3.1, 0.3.0, 0.2.5, 0.2.4, 0.2.3, 0.2.2, 0.2.1, 0.2.0, 0.1.2, 0.1.1, 0.1.0
npm ERR! notarget 
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/habibridho/Desktop/react-projects/Nebengers-FrontEnd/npm-debug.log
```

Proposed solution: use latest version of extract-text-webpack-plugin.